### PR TITLE
bumping omniauth and some configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ end
 OmniAuth Tequila authenticates with the EPFL server over SSL by default. However, it supports the following configuration options:
 
   * `host` - Defines the host of your Tequila server
+  * `require_group` - Defines the group that will have access to the service
+  * `service_name` - Define the name the service will authenticate with to tequila
   * `path` - Defines the URL relative to the host that the application sits behind
   * `port` - The port to use for your configured Tequila `host`
   * `ssl` - true to connect to your Tequila server over SSL

--- a/lib/omniauth-tequila.rb
+++ b/lib/omniauth-tequila.rb
@@ -1,1 +1,3 @@
+require "omniauth"
 require "omniauth/tequila"
+

--- a/lib/omniauth/strategies/tequila.rb
+++ b/lib/omniauth/strategies/tequila.rb
@@ -14,6 +14,8 @@ module OmniAuth
       option :name, :tequila # Required property by OmniAuth::Strategy
 
       option :host, 'tequila.epfl.ch'
+      option :require_group, 'my-group'
+      option :service_name, 'Omniauth'
       option :port, nil
       option :path, '/cgi-bin/tequila'
       option :ssl, true
@@ -92,8 +94,8 @@ module OmniAuth
       def get_request_key
         # NB: You might want to set the service and required group yourself.
         request_fields = @options[:request_info].values << @options[:uid_field]
-        body = 'urlaccess=' + callback_url + "\nservice=Omniauth\n" +
-          'request=' + request_fields.join(',') + "\nrequire=group=my-group"
+        body = 'urlaccess=' + callback_url + "\nservice=" + @options[:service_name] + "\n" +
+          'request=' + request_fields.join(',') + "\nrequire=group=" + @options[:require_group]
         tequila_post '/createrequest', body
       end
 

--- a/omniauth-tequila.gemspec
+++ b/omniauth-tequila.gemspec
@@ -18,7 +18,7 @@ EOF
   gem.require_paths = ['lib']
   gem.version       = Omniauth::Tequila::VERSION
 
-  gem.add_dependency 'omniauth',                '~> 1.1.0'
+  gem.add_dependency 'omniauth',                '~> 1.2.0'
   gem.add_dependency 'addressable',             '~> 2.3'
 
   gem.add_development_dependency 'rake',        '~> 0.9'

--- a/spec/omniauth/strategies/tequila_spec.rb
+++ b/spec/omniauth/strategies/tequila_spec.rb
@@ -18,6 +18,8 @@ describe OmniAuth::Strategies::Tequila, type: :strategy do
     it 'points to the EPFL server over SSL' do
       should include('ssl' => true)
       should include('host' => 'tequila.epfl.ch')
+      should include('require_group' => 'my-group')
+      should include('service_name' => 'Omniauth')
       should include('port' => nil)
       should include('path' => '/cgi-bin/tequila')
       should include('uid_field' => :uniqueid)


### PR DESCRIPTION
I had some issue installing omniauth on the latest version of gitlab, so I bumped the version of omniauth.
Then I put some of the variable used in the tequila authentication into parameters, as I needed to change them.
The default should stay the same as before.
